### PR TITLE
Change use directive syntax

### DIFF
--- a/Compiler/Compiler.cs
+++ b/Compiler/Compiler.cs
@@ -774,14 +774,6 @@ namespace Osprey
 						newFiles.Add(realFile);
 					}
 				}
-				else if (use is UseModuleDirective)
-				{
-					var modName = ((UseModuleDirective)use).Name.Parts.JoinString(".");
-					modules.Add(modName);
-					Notice(CompilerVerbosity.ExtraVerbose,
-						"Adding reference to module '{0}', from '{1}'",
-						modName, docFile);
-				}
 		}
 
 		private void BuildProjectNamespace()

--- a/Parser/Node.cs
+++ b/Parser/Node.cs
@@ -112,22 +112,6 @@ namespace Osprey.Nodes
 		public virtual bool ResolveNames(Namespace globalNamespace, bool firstPass) { return false; }
 	}
 
-	public sealed class UseModuleDirective : UseDirective
-	{
-		public UseModuleDirective(QualifiedName name)
-		{
-			Name = name;
-		}
-
-		/// <summary>The name of the module to import.</summary>
-		public QualifiedName Name;
-
-		public override string ToString(int indent)
-		{
-			return new string('\t', indent) + "use " + Name + ";";
-		}
-	}
-
 	public sealed class UseFileDirective : UseDirective
 	{
 		public UseFileDirective(StringLiteral name)
@@ -159,7 +143,7 @@ namespace Osprey.Nodes
 
 		public override string ToString(int indent)
 		{
-			return new string('\t', indent) + "use namespace " + Name + ";";
+			return new string('\t', indent) + "use " + Name + ";";
 		}
 
 		public override bool ResolveNames(Namespace globalNamespace, bool firstPass)

--- a/Parser/Parser.cs
+++ b/Parser/Parser.cs
@@ -595,12 +595,6 @@ namespace Osprey
 				Expect(ref i, TokenType.Semicolon);
 				result = new UseFileDirective(new StringLiteral((StringToken)token));
 			}
-			else if (Accept(ref i, TokenType.Namespace)) // use namespace foo.bar.baz;
-			{
-				var name = ParseQualifiedName(ref i);
-				Expect(ref i, TokenType.Semicolon);
-				result = new UseNamespaceDirective(name);
-			}
 			else if (Accept(i, TokenType.Identifier)) // use foo.bar.baz;  or  use alias = foo.bar.baz;
 			{
 				string aliasName = null;
@@ -615,10 +609,10 @@ namespace Osprey
 				if (aliasName != null)
 					result = new UseAliasDirective(aliasName, name);
 				else
-					result = new UseModuleDirective(name);
+					result = new UseNamespaceDirective(name);
 			}
 			else
-				ParseError(i, "Expected identifier, string or 'namespace'.");
+				ParseError(i, "Expected identifier or string.");
 
 			result.StartIndex = start;
 			result.EndIndex = end;


### PR DESCRIPTION
The module import directive, 'use x;', is removed. Only '/import' can be used to import modules now. The purpose of this is to pave the way for better dependency management, in the shape of build files, which will be implemented in ospc (https://github.com/osprey-lang/ospc).

At the same time, the namespace import directive, 'use namespace x;', is shortened to just 'use x;', which gets rid of one of Osprey's more annoying warts. The new syntax fits better into the language.

Needless to say, this change breaks an awful lot of code - in fact, just about all Osprey source files are now invalid! Oh dear.