### PR TITLE
Use directive syntax Mk III

### DIFF
--- a/Module/ModuleWriter.cs
+++ b/Module/ModuleWriter.cs
@@ -273,8 +273,11 @@ namespace Osprey
 
 		public ConstantDef CreateConstantDef(Members.GlobalConstant constant)
 		{
+			var nameToken = module.GetStringId(constant.FullName);
 			var value = CreateConstantValue(constant.Value);
-			return new ConstantDef(constant, value);
+			var result = new ConstantDef(constant, nameToken, value);
+			definitions.ConstantDefs.Add(result);
+			return result;
 		}
 
 		public ModuleRef CreateModuleRef(Module module)

--- a/ModuleFile/DefinitionsSection.cs
+++ b/ModuleFile/DefinitionsSection.cs
@@ -532,13 +532,15 @@ namespace Osprey.ModuleFile
 
 	public class ConstantDef : FileObject
 	{
-		public ConstantDef(Members.GlobalConstant constant, ConstantValueObject value)
+		public ConstantDef(Members.GlobalConstant constant, uint nameToken, ConstantValueObject value)
 		{
 			this.Constant = constant;
+			this.NameToken = nameToken;
 			this.Value = value;
 		}
 
 		public readonly Members.GlobalConstant Constant;
+		public readonly uint NameToken;
 		public readonly ConstantValueObject Value;
 
 		public override uint Size { get { return 16; } }
@@ -549,9 +551,10 @@ namespace Osprey.ModuleFile
 		{
 			var data = new Raw.ConstantDefStruct();
 			data.Flags = GetConstantFlags();
-			data.Name = new MetadataToken(Constant.Module.GetStringId(Constant.FullName));
+			data.Name = new MetadataToken(NameToken);
 			data.Annotations = 0u; // not supported
 			data.Value = Value.ToRva<Raw.ConstantValueStruct>();
+			view.Write(this.Address, ref data);
 		}
 
 		private Raw.ConstantFlags GetConstantFlags()

--- a/Parser/ContextualType.cs
+++ b/Parser/ContextualType.cs
@@ -8,7 +8,7 @@ namespace Osprey
 	/// <summary>
 	/// Represents the contextual type of an identifier token. In addition to being a plain
 	/// identifier, some sequences of characters are used contextually as keywords. The standard
-	/// language includes contextual keywords "to" and "version". Extension keywords are also
+	/// language includes contextual keywords "get", "set" and "as". Extension keywords are also
 	/// implemented as contextual keywords.
 	/// </summary>
 	public enum ContextualType
@@ -19,6 +19,8 @@ namespace Osprey
 		Get = 1,
 		/// <summary>set</summary>
 		Set = 2,
+		/// <summary>as</summary>
+		As = 3,
 		/// <summary>__primitive</summary>
 		Primitive = 5,
 		/// <summary>__init_type</summary>

--- a/Parser/TokenFacts.cs
+++ b/Parser/TokenFacts.cs
@@ -65,6 +65,7 @@ namespace Osprey
 		{
 			{"get", ContextualType.Get},
 			{"set", ContextualType.Set},
+			{"as", ContextualType.As},
 			{"__primitive", ContextualType.Primitive},
 			{"__init_type", ContextualType.InitType},
 			{"__extern", ContextualType.Extern},


### PR DESCRIPTION
Osprey's use directive syntax is made more ergonomic with this pull request. Previously, if you wanted to import only a single member from a namespace, it was necessary to use an alias, like so:

    use Method = aves.reflection.Method;

If you wanted several members from the same namespace - say, if you wanted to import some trigonometric things from `math` but keep the rest out of the file's scope - you were required to use multiple use directives:

    use pi = math.pi;
    use sin = math.sin;
    use cos = math.cos;
    use tan = math.tan;

With this change, a use directive by default only imports the single member mentioned by fully qualified name:

    use aves.reflection.Method;

or a list of members:

    use math.{pi, sin, cos, tan};

Since importing all members from a namespace is useful functionality, that is now available using the following syntax:

    use aves.*;
    use io.*;

This behaves the same as the previous `use aves;` form.

Moreover, aliases can be defined using the new contextual `as` keyword:

    use aves.reflection as refl;
    use math.{
      asin as arcsin,
      acos as arccos,
      atan as arctan,
    };
    use foo.T as FooT;
    use bar.T as BarT;

    // aves.reflection.Method can be referred to as refl.Method here

This change invalidates essentially all existing Osprey code.